### PR TITLE
Fix mixed content warning for background images.

### DIFF
--- a/layouts/partials/functions/parse_block_v2.html
+++ b/layouts/partials/functions/parse_block_v2.html
@@ -74,7 +74,7 @@ UPGRADE CONTEXT:
     {{ if ne $bg_img.MediaType.SubType "svg" }}
       {{ $bg_img = $bg_img.Fit "1920x1920 webp" }}
     {{ end }}
-    {{ $style_bg = printf "%sbackground-image: url('%s');" $style_bg $bg_img.Permalink }}
+    {{ $style_bg = printf "%sbackground-image: url('%s');" $style_bg $bg_img.RelPermalink }}
   {{ else }}
     {{ errorf "Couldn't find `%s` in the `assets/media/` folder - please add it." $bg.image.filename }}
   {{ end }}


### PR DESCRIPTION
Background images were loading over HTTP, causing browser security warnings. Changed URL generation to use relative paths that inherit the HTTPS protocol automatically, eliminating mixed content issues.