### PR TITLE
Fix mixed content warning for background images.

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -30,6 +30,8 @@ pagination:
   pagerSize: 10
 enableEmoji: true
 enableRobotsTXT: true
+relativeURLs: false
+canonifyURLs: false
 footnotereturnlinkcontents: <sup>^</sup>
 ignoreFiles: [\.ipynb$, .ipynb_checkpoints$, \.Rmd$, \.Rmarkdown$, _cache$]
 permalinks:


### PR DESCRIPTION
Background images were loading over HTTP, causing browser security warnings.