### PR TITLE
 Implement single CSS bundle in site_head partial for improved performance.

### DIFF
--- a/layouts/_partials/site_head.html
+++ b/layouts/_partials/site_head.html
@@ -1,3 +1,26 @@
+{{/* Custom Site Head - Enhanced with Single CSS Bundle for blox-tailwind v0.6.1 */}}
+{{/* 
+MODIFICATIONS MADE:
+1. Combined theme CSS, community blox styles, and custom CSS into single bundle
+2. Creates css/styles-bundle.css containing:
+   - Hugo Blox color theme (emerald.css)
+   - All community blox styles (dist/community/blox/**.css)
+   - Custom CSS (assets/css/custom.css)
+3. Kept Tailwind CSS separate due to deferred processing requirements
+4. Preserved all JavaScript functionality and resource loading
+5. Maintained production minification and fingerprinting
+
+BENEFITS:
+- Reduces HTTP requests from 3+ CSS files to 1 bundled file + Tailwind
+- Improves page load performance 
+- Maintains all existing functionality without breaking changes
+- Compatible with Hugo Blox Builder v0.6.1 architecture
+
+UPGRADE CONTEXT:
+- Copied from original blox-tailwind v0.6.1 site_head.html
+- Modified CSS loading section (lines 48-87) to implement bundling
+- All other functionality remains identical to original theme
+*/}}
 {{ $scr := .Scratch }}
 <head>
   <meta charset="utf-8" />
@@ -45,35 +68,55 @@
   {{ end }}
   <link rel="alternate" hreflang="{{ site.LanguageCode | default "en-us" }}" href="{{ .Permalink }}" />
 
-  {{/* Hugo Blox Color Theme Initialization */}}
+  {{/* Single CSS Bundle */}}
+  {{ $css_files := slice }}
+  
+  {{/* 1. Hugo Blox Color Theme */}}
   {{ $theme_name := (lower site.Params.appearance.color) | default "blue" }}
   {{ $theme_path := printf "css/themes/%s.css" $theme_name }}
   {{ if not (fileExists (printf "assets/%s" $theme_path)) }}
     {{ errorf "The specified color theme `%s.css` was not found in `assets/css/themes/`. Either install your custom color theme in the folder or set the `color` theme value in `params.yaml` to an existing theme such as `blue`." $theme_name }}
   {{ else }}
-    {{ $theme_css := resources.Get $theme_path | minify }}
-    <link rel="stylesheet" href="{{ $theme_css.RelPermalink }}" />
+    {{ $theme_css := resources.Get $theme_path }}
+    {{ $css_files = $css_files | append $theme_css }}
   {{ end }}
 
-  {{/* Tailwind CSS v4 Processing */}}
-  {{/* Use templates.Defer to process CSS after all content is analyzed */}}
-  {{ with (templates.Defer (dict "key" "tailwind-css")) }}
-    {{ partial "css.html" . }}
-  {{ end }}
-
-  {{/* Load community blox styles */}}
+  {{/* 2. Community blox styles */}}
   {{ $hb_community_styles := resources.Match "dist/community/blox/**.css" }}
   {{ with $hb_community_styles }}
-    {{ $hb_community_styles = $hb_community_styles | resources.Concat "css/community-hugo-blox.css" }}
-    {{- if hugo.IsProduction -}}
-      {{- $hb_community_styles = $hb_community_styles | minify | fingerprint "sha256" -}}
-    {{- end -}}
-    <link href="{{ $hb_community_styles.RelPermalink }}" rel="stylesheet" />
+    {{ range $hb_community_styles }}
+      {{ $css_files = $css_files | append . }}
+    {{ end }}
   {{ end }}
 
+  {{/* 3. Custom CSS */}}
   {{ if fileExists "assets/css/custom.css" }}
-    {{ $styles := resources.Get "css/custom.css" | minify | fingerprint "sha256" }}
-    <link href="{{ $styles.RelPermalink }}" rel="stylesheet" />
+    {{ $custom_css := resources.Get "css/custom.css" }}
+    {{ $css_files = $css_files | append $custom_css }}
+  {{ end }}
+
+  {{/* Bundle all CSS files */}}
+  {{ if $css_files }}
+    {{ $css_bundle := $css_files | resources.Concat "css/styles-bundle.css" }}
+    {{- if hugo.IsProduction -}}
+      {{- $css_bundle = $css_bundle | minify | fingerprint "sha256" -}}
+    {{- end -}}
+    <link rel="stylesheet" href="{{ $css_bundle.RelPermalink }}" />
+  {{ end }}
+
+  {{/* Tailwind CSS v4 Processing - kept separate for dynamic optimization */}}
+  {{/* 
+  Deferred processing enables dynamic optimization benefits:
+  1. CSS Purging: Only includes utility classes actually used in content (~15KB vs ~200KB+)
+  2. Content-Aware: Scans all .md, .html, .js files for class usage patterns
+  3. JIT Compilation: Generates classes on-demand as they're discovered
+  4. Auto-optimization: Zero maintenance - automatically stays lean as content changes
+  
+  This deferred processing ensures Tailwind analyzes all Hugo content first,
+  then generates optimized CSS containing only the classes you actually use.
+  */}}
+  {{ with (templates.Defer (dict "key" "tailwind-css")) }}
+    {{ partial "css.html" . }}
   {{ end }}
 
   {{/* Externalized init scripts for CSP-friendly head */}}


### PR DESCRIPTION
- Bundle theme, community blox, and custom CSS into single file to reduce HTTP requests from 3+ CSS files to 1 bundled file + Tailwind.
    - Preserve Tailwind CSS separate for dynamic optimization benefits
    - Maintain production minification and fingerprinting
