### PR TITLE
Fix bio paragraph spacing for production builds

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -14,6 +14,14 @@ footer {
     background: white !important;
 }
 
+/* Reduce spacing between paragraphs in About Me section
+   Note: Using CSS instead of Tailwind prose-p:!my-[0.6rem] because
+   Hugo Blox production build doesn't compile arbitrary Tailwind classes */
+.bio-text p {
+    margin-top: 0.6rem !important;
+    margin-bottom: 0.6rem !important;
+}
+
 /* Reduce spacing between section headers and content */
 .resume-biography h2 + div,
 .resume-biography h3 + ul {


### PR DESCRIPTION
  - Move paragraph spacing from Tailwind arbitrary class to custom.css
  - Hugo Blox production build doesn't compile arbitrary Tailwind classes like prose-p:!my-[0.6rem], causing spacing to fail on GitHub Pages
  - Works in dev (JIT mode) but fails in prod (pre-compiled CSS)
  - Solution: Use standard CSS rule in custom.css for consistent behavior across all environments